### PR TITLE
chore: update color package usage to support package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.1
 
 require (
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
-	github.com/gookit/color v1.6.0
 	github.com/goravel/framework v1.16.3
 	github.com/stretchr/testify v1.11.1
 )
@@ -23,6 +22,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/gookit/color v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect

--- a/oss.go
+++ b/oss.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
-	"github.com/gookit/color"
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/filesystem"
 	contractshttp "github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/color"
 	"github.com/goravel/framework/support/str"
 )
 
@@ -356,7 +356,7 @@ func (r *Oss) WithContext(ctx context.Context) filesystem.Driver {
 
 	driver, err := NewOss(ctx, r.config, r.disk)
 	if err != nil {
-		color.Redf("init %s error: %+v\n", r.disk, err)
+		color.Red().Printfln("init %s error: %+v", r.disk, err)
 
 		return nil
 	}

--- a/oss_test.go
+++ b/oss_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gookit/color"
 	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/color"
 	"github.com/stretchr/testify/assert"
 
 	filesystemcontract "github.com/goravel/framework/contracts/filesystem"
@@ -19,7 +19,7 @@ import (
 
 func TestStorage(t *testing.T) {
 	if os.Getenv("ALIYUN_ACCESS_KEY_ID") == "" {
-		color.Redln("No filesystem tests run, please add oss configuration: ALIYUN_ACCESS_KEY_ID= ALIYUN_ACCESS_KEY_SECRET= ALIYUN_BUCKET= ALIYUN_URL= ALIYUN_ENDPOINT= go test ./...")
+		color.Red().Println("No filesystem tests run, please add oss configuration: ALIYUN_ACCESS_KEY_ID= ALIYUN_ACCESS_KEY_SECRET= ALIYUN_BUCKET= ALIYUN_URL= ALIYUN_ENDPOINT= go test ./...")
 		return
 	}
 


### PR DESCRIPTION
## 📑 Description

Replaces direct usage of the external `gookit/color` package with the internal `github.com/goravel/framework/support/color` package, and updates the method calls for printing colored output. Additionally, the dependency on `gookit/color` is now marked as indirect in `go.mod`.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
